### PR TITLE
Fix typo of `setion` to `section`

### DIFF
--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -87,7 +87,7 @@ if (siteSelectInput && usernameInput) {
 const verifyAccountButton = document.getElementById("verify-account");
 if (verifyAccountButton) {
   const accountID = document.querySelector<HTMLElement>(
-    "setion[data-account-id]"
+    "section[data-account-id]"
   )?.dataset.accountId;
   if (accountID) {
     verifyAccountButton.addEventListener("click", (ev) => {


### PR DESCRIPTION
Account verification for FurAffinity was not working because the query selector was looking for `setion` instead of `section`.